### PR TITLE
Upgrades to Scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - ci/sbt-setup.sh
 - ci/sbt-setup-version.sh
 script:
-- sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; test; package; scripted' && ci/sbt-deploy.sh
+- sbt -Dsbt.global.base=$TRAVIS_BUILD_DIR/ci '; + test; + package; scripted' && ci/sbt-deploy.sh
   core generator && ci/sbt-deploy-ivy.sh plugin && ci/gh-pages.sh
 after_script:
 - rm -rf ci

--- a/generator/src/test/scala/au/com/cba/omnia/humbug/HumbugSpec.scala
+++ b/generator/src/test/scala/au/com/cba/omnia/humbug/HumbugSpec.scala
@@ -20,12 +20,13 @@ import java.io.File
 
 import com.twitter.bijection.scrooge.CompactScalaCodec
 
-import com.cba.omnia.test.Spec
+import org.specs2.{ScalaCheck, Specification}
+import org.specs2.matcher.ThrownExpectations
 
 import au.com.cba.omnia.humbug.test._
 import au.com.cba.omnia.humbug.test.Arbitraries._
 
-class HumbugSpec extends Spec { def is = s2"""
+class HumbugSpec extends Specification with ThrownExpectations with ScalaCheck { def is = s2"""
 
 Humbug
 ======

--- a/generator/src/test/scala/au/com/cba/omnia/humbug/test/Arbitraries.scala
+++ b/generator/src/test/scala/au/com/cba/omnia/humbug/test/Arbitraries.scala
@@ -51,7 +51,7 @@ object Arbitraries {
     arbitrary[Short] |@| arbitrary[List[String]]) { case (s, l) =>
       val listish = new Listish()
       listish.short = s
-      listish.list  = l
+      listish.listy  = l
 
       listish
     })
@@ -60,7 +60,7 @@ object Arbitraries {
     arbitrary[Int] |@| arbitrary[Map[String, Int]]) { case (i, m) =>
       val mapish = new Mapish()
       mapish.int = i
-      mapish.map = m
+      mapish.mapy = m
 
       mapish
   })
@@ -68,7 +68,7 @@ object Arbitraries {
   implicit def NestedArbitrary: Arbitrary[Nested] = Arbitrary(
     arbitrary[Map[String, List[Int]]].map { l =>
       val nested = new Nested
-      nested.map = l
+      nested.mapy = l
 
       nested
     })

--- a/generator/src/test/thrift/Types.thrift
+++ b/generator/src/test/thrift/Types.thrift
@@ -28,14 +28,14 @@ struct Types {
 
 struct Listish {
   1: i16 short
-  2: list<string> list
+  2: list<string> listy
 }
 
 struct Mapish {
   1: i32 int
-  2: map<string, i32> map
+  2: map<string, i32> mapy
 }
 
 struct Nested {
-  1: map<string, list<i32>> map
+  1: map<string, list<i32>> mapy
 }

--- a/plugin/src/sbt-test/humbug/simple/build.sbt
+++ b/plugin/src/sbt-test/humbug/simple/build.sbt
@@ -11,11 +11,16 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+
+import au.com.cba.omnia.uniform.dependency.UniformDependencyPlugin._
+
 import au.com.cba.omnia.humbug.HumbugSBT
 
 version := "0.1"
 
-scalaVersion := "2.10.2"
+scalaVersion := "2.10.5"
+
+uniformDependencySettings
 
 HumbugSBT.humbugSettings
 

--- a/plugin/src/sbt-test/humbug/simple/project/plugins.sbt
+++ b/plugin/src/sbt-test/humbug/simple/project/plugins.sbt
@@ -22,7 +22,7 @@
 
 resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
 
-val uniformVersion = "0.1.0-20140604023218-251a40c"
+val uniformVersion = "1.2.2-20150429235901-67f611b"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,10 +14,12 @@
 
 resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
 
-val uniformVersion = "1.0.0-20150325230450-5af497f"
+val uniformVersion = "1.2.2-20150429235901-67f611b"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-dependency" % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-assembly"   % uniformVersion)
+
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.5.1"
+version in ThisBuild := "0.6.0"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Changes the project so that core, generator and plugin are published for
Scala 2.10 and core is also published for Scala 2.11.

* Removes omniaTest dependency since it didn't really add anything.
* Fixed compilation errors/warnings.
* Renamed thrift struct fields since Scrooge is now stricter and the
  names can't be the same as reserved names.
* Adds sbt-doge as plugin to enable proper cross compilation.