### PR TITLE
Fixes humbug plugin so only scrooge sources are registered for source code generation.

### DIFF
--- a/plugin/src/sbt-test/humbug/simple/test
+++ b/plugin/src/sbt-test/humbug/simple/test
@@ -8,4 +8,6 @@ $ exists target/scala-2.10/src_managed/main/au/com/cba/omnia/humbug/test/Large.s
 
 > 'set au.com.cba.omnia.humbug.HumbugSBT.humbugThriftValidators in Compile += au.com.cba.omnia.humbug.ThriftValidator(_ => List("failure"))'
 
+> clean
+
 -> compile

--- a/project/build.scala
+++ b/project/build.scala
@@ -39,7 +39,7 @@ object build extends Build {
     strictDependencySettings ++
     uniform.docSettings("https://github.com/CommBank/humbug") ++
     Seq(
-      updateOptions      := updateOptions.value.withCachedResolution(true)
+      updateOptions := updateOptions.value.withCachedResolution(true)
     )
 
   lazy val scala210Settings = Seq(
@@ -91,7 +91,7 @@ object build extends Build {
       inConfig(Test)(thriftSettings) ++
       Seq(
         libraryDependencies ++= depend.hadoopClasspath ++ depend.scalaz() ++ Seq(
-          "com.twitter"    %% "scrooge-generator" % depend.versions.scrooge,
+          "com.twitter"    %% "scrooge-generator"         % depend.versions.scrooge,
           "org.specs2"     %% "specs2-core"               % depend.versions.specs      % "test"
             exclude("org.ow2.asm", "asm"),
           "org.specs2"     %% "specs2-scalacheck"         % depend.versions.specs      % "test" 
@@ -106,7 +106,7 @@ object build extends Build {
             // exclude clashes with scrooge-generator
             exclude("com.twitter", s"scrooge-core_${scalaBinaryVersion.value}")
             exclude("com.twitter", s"util-core_${scalaBinaryVersion.value}")
-            exclude("com.twitter", s"util-codec_${scalaBinaryVersion.value}")//,
+            exclude("com.twitter", s"util-codec_${scalaBinaryVersion.value}")
         ).map(noHadoop(_))
       )
   ).dependsOn(core)
@@ -129,11 +129,12 @@ object build extends Build {
       sourceManaged
     ) map { (out, base, cp, outputDir) =>
       val files = (s"find ${base.getAbsolutePath} -name *.thrift" !!).split("\n")
-      val cmd = s"java -cp ${cp.files.absString} au.com.cba.omnia.humbug.Main ${outputDir.getAbsolutePath} ${files.mkString(" ")}"
+      val dst = outputDir / "humbug"
+      val cmd = s"java -cp ${cp.files.absString} au.com.cba.omnia.humbug.Main ${dst.getAbsolutePath} ${files.mkString(" ")}"
       out.log.info(cmd)
       cmd ! out.log
 
-      (outputDir ** "*.scala").get.toSeq
+      (dst ** "*.scala").get.toSeq
     },
     sourceGenerators <+= compileThrift
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@
 
 resolvers += Resolver.url("commbank-releases-ivy", new URL("http://commbank.artifactoryonline.com/commbank/ext-releases-local-ivy"))(Patterns("[organization]/[module]_[scalaVersion]_[sbtVersion]/[revision]/[artifact](-[classifier])-[revision].[ext]"))
 
-val uniformVersion = "1.2.2-20150429235901-67f611b"
+val uniformVersion = "1.2.3-20150512045744-cef95d6"
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-core"       % uniformVersion)
 
@@ -22,4 +22,4 @@ addSbtPlugin("au.com.cba.omnia" % "uniform-dependency" % uniformVersion)
 
 addSbtPlugin("au.com.cba.omnia" % "uniform-assembly"   % uniformVersion)
 
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")
+addSbtPlugin("com.eed3si9n"     % "sbt-doge"           % "0.1.5")

--- a/version.sbt
+++ b/version.sbt
@@ -12,7 +12,7 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-version in ThisBuild := "0.6.0"
+version in ThisBuild := "0.6.1"
 
 uniqueVersionSettings
 


### PR DESCRIPTION
Previously the plugin would register all files under `src_managed` with
the compiler even files that it didn't generate causing some files to be
registered twice. The Scala 2.11 compiler no longer accepts that.

This changes the plugin to it know which files it generated and it uses
`FileFunction.cached` to cache thrift code generation.